### PR TITLE
set to return bleurt and mpnet results

### DIFF
--- a/models/answer.py
+++ b/models/answer.py
@@ -6,5 +6,6 @@ class AnswerInput(InputBase):
 
 
 class AnswerResults(ResultsBase):
-    score: float  # BLEURT or some other score
+    score: float  # in [0,1,2] 0 means incorrect, 2 means correct, 1 means model disagreement
     is_passing: bool
+    results: dict # dictionary contining BLEURT score and MPnet label

--- a/pipelines/answer.py
+++ b/pipelines/answer.py
@@ -2,9 +2,7 @@
 Defines AnswerPipeline:
 It loads a Bleurt model and an MPnet model for scoring a short answer.
 The __call__ method takes a candidate and a reference answer as inputs.
-If both models agree that the candidate is correct, return 2.
-If the models disagree, return 1.
-If both models agree that it is incorrect, return 0.
+Return a dictionary with the bleurt score and the mpnet label
 """
 
 from transformers import pipeline
@@ -27,24 +25,7 @@ class AnswerPipeline:
         bleurt_sequence = f"{candidate}[SEP]{reference}"
         mpnet_sequence = f"{candidate}</s>{reference}"
 
-        # Get bleurt results
-        bleurt_score = self.bleurt_classifier(bleurt_sequence)[0]["score"]
-        if bleurt_score >= self.bleurt_threshold:
-            bleurt_passing = True
-        else:
-            bleurt_passing = False
+        bleurt_score = self.bleurt_classifier(bleurt_sequence)[0]['score']
+        mpnet_score = self.mpnet_classifier(mpnet_sequence)[0]['label']
 
-        # Get MPnet results
-        mpnet_score = self.mpnet_classifier(mpnet_sequence)[0]["label"]
-        if mpnet_score == "correct_answer":
-            mpnet_passing = True
-        elif mpnet_score == "incorrect_answer":
-            mpnet_passing = False
-
-        # Majority voting
-        if bleurt_passing and mpnet_passing:
-            return 2
-        elif bleurt_passing or mpnet_passing:
-            return 1
-        else:
-            return 0
+        return {'bleurt_score':bleurt_score, 'mpnet_score':mpnet_score}

--- a/src/answer_eval.py
+++ b/src/answer_eval.py
@@ -42,11 +42,35 @@ class Answer:
         correct_answer = self.data["answer"]
         res = answer_pipe(self.answer, correct_answer)
 
-        self.results["score"] = res
-        if res < 2:
+        self.results["results"] = res
+
+        # Get bleurt results
+        bleurt_score = res['bleurt_score']
+        if bleurt_score > 0.7:
+            bleurt_res = True
+        else:
+            bleurt_res = False
+
+        # Get MPnet results
+        mpnet_score = res['mpnet_score']
+        if mpnet_score == 'correct_answer':
+            mpnet_res = True
+        elif mpnet_score == 'incorrect_answer':
+            mpnet_res = False        
+
+        # Majority voting
+        if mpnet_res == True and bleurt_res == True:
+            self.results["score"] = 2
+        elif mpnet_res == False and bleurt_res == False:
+            self.results["score"] = 0
+        else:
+            self.results["score"] = 1
+
+        # is_passing results
+        if self.results["score"] < 2:
             self.results["is_passing"] = False
         else:
-            self.results["is_passing"] = True
+            self.results["is_passing"] = True        
 
 
 async def answer_score(answer_input: AnswerInput) -> AnswerResults:


### PR DESCRIPTION
Updates the api to return raw scores from BLEURT and labels from MPnet. Logic is now processed in model_eval.py rather than in answer.py.