### PR TITLE
Stairs v0.2

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -2,7 +2,7 @@ from .models.chat import ChatInput, PromptInput
 from .models.embedding import RetrievalInput
 from typing import AsyncGenerator
 from .embedding import chunks_retrieve
-from .pipelines.chat import ChatPipeline
+from .pipelines.chat import chat_pipeline
 from .connections.strapi import Strapi
 
 from vllm.sampling_params import SamplingParams
@@ -80,11 +80,11 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     # Join the prompt components together, ending with the (modified) user message
     prompt = "".join([preface, sample_conversation, additional_context, history, msg])
 
-    return await ChatPipeline(prompt, sampling_params)
+    return await chat_pipeline(prompt, sampling_params)
 
 
 async def unmoderated_chat(raw_chat_input: PromptInput) -> AsyncGenerator[bytes, None]:
     sampling_params = SamplingParams(
         temperature=0.4, max_tokens=4096, stop_token_ids=[11889]
     )
-    return await ChatPipeline(raw_chat_input.message, sampling_params)
+    return await chat_pipeline(raw_chat_input.message, sampling_params)

--- a/src/chat.py
+++ b/src/chat.py
@@ -14,12 +14,12 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     # Adding in the specific name of the textbook majorly improved response quality
     text_meta = await strapi.get_text_meta(chat_input.page_slug)
 
-    # Stop generation when the LLM generates the token for "user" (1792)
+    # Stop generation when the LLM generates the token for "USER" (11889)
     # This prevents the LLM from having a conversation with itself
     # But we should have a better method for this because
-    # this will stop generation if the LLM uses the word "user" in a sentence.
+    # this will stop generation if the LLM uses the word "USER" in a sentence.
     sampling_params = SamplingParams(
-        temperature=0.4, max_tokens=4096, stop_token_ids=[1792]
+        temperature=0.4, max_tokens=4096, stop_token_ids=[11889]
     )
 
     # This phrasing seems to work well. Modified from NeMo Guardrails
@@ -33,16 +33,16 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     # Modified from Guardrails
     sample_conversation = (
         "\n# This is how a conversation between a user and the bot can go:"
-        '\nuser: "Hello there!"'
-        '\nbot: "Hello! How can I assist you today?"'
-        '\nuser: "What can you do for me?"'
-        '\nbot: "I am an AI assistant which helps answer questions'
+        '\nUSER: "Hello there!"'
+        '\nBOT: "Hello! How can I assist you today?"'
+        '\nUSER: "What can you do for me?"'
+        '\nBOT: "I am an AI assistant which helps answer questions'
         f' based on {text_meta.Title}."'
-        '\nuser: "What do you think about politics?"'
-        '\nbot: "Sorry, I don\'t like to talk about politics."'
-        '\nuser: "I just read an educational text on the history of curse words.'
+        '\nUSER: "What do you think about politics?"'
+        '\nBOT: "Sorry, I don\'t like to talk about politics."'
+        '\nUSER: "I just read an educational text on the history of curse words.'
         ' What can you tell me about the etymology of the word fuck?"'
-        '\nbot: "Sorry, but I don\t have any information about that word.'
+        '\nBOT: "Sorry, but I don\t have any information about that word.'
         f'Would you like to ask me a question about {text_meta.Title}?"'
     )
 
@@ -68,14 +68,14 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     # that the bot will use as a reference.
 
     # Get conversation history
-    history = "\n# This is the current conversation between the user and the bot:"
+    history = "\n# This is the current conversation between the USER and the bot:"
     if chat_input.history:
         for source, past_msg in chat_input.history.items():
             history += f"\n{source}: {past_msg}"
 
     # We need to inject "bot: " at the end of the user message to prevent
     # the LLM from completing an inappropriate user message.
-    msg = f"\nuser: {chat_input.message}\nbot:"
+    msg = f"\nUSER: {chat_input.message}\nBOT:"
 
     # Join the prompt components together, ending with the (modified) user message
     prompt = "".join([preface, sample_conversation, additional_context, history, msg])
@@ -85,6 +85,6 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
 
 async def unmoderated_chat(raw_chat_input: PromptInput) -> AsyncGenerator[bytes, None]:
     sampling_params = SamplingParams(
-        temperature=0.4, max_tokens=4096, stop_token_ids=[1792]
+        temperature=0.4, max_tokens=4096, stop_token_ids=[11889]
     )
     return await ChatPipeline(raw_chat_input.message, sampling_params)

--- a/src/connections/strapi.py
+++ b/src/connections/strapi.py
@@ -21,7 +21,12 @@ class Strapi:
         async with httpx.AsyncClient() as client:
             r = await client.get(url, headers=self.headers, params=params)
             if r.status_code != 200:
-                raise Exception(f"Error {r.status_code}: {r.reason_phrase}")
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Error connecting to Strapi {r.status_code}: {r.reason_phrase}"
+                    ),
+                )
             result: dict = r.json()
             return result
 

--- a/src/embedding.py
+++ b/src/embedding.py
@@ -47,3 +47,19 @@ async def chunks_retrieve(input_body: RetrievalInput) -> RetrievalResults:
         raise HTTPException(status_code=500, detail=str(error))
 
     return RetrievalResults(matches=matches)
+
+
+async def page_similarity(embedding: list[float], page_slug: str) -> float:
+    db = get_vector_store()
+    query_params = {
+        "summary_embedding": embedding,
+        "target_page": page_slug,
+    }
+    try:
+        similarity = (
+            db.rpc("page_similarity", query_params).execute().data[0]["similarity"]
+        )
+    except (TypeError, AttributeError) as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+    return similarity

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,6 @@ from fastapi.responses import StreamingResponse
 from fastapi import FastAPI, HTTPException, Response
 from typing import Union, AsyncGenerator
 
-from .sert import sert_generate
 from .summary_eval_supabase import summary_score_supabase
 from .summary_eval import summary_score
 from .summary_feedback import get_feedback
@@ -126,6 +125,7 @@ if not os.environ.get("ENV") == "development":
     import torch
     from src.embedding import embedding_generate, chunks_retrieve
     from src.chat import moderated_chat, unmoderated_chat
+    from .sert import sert_generate
 
     @app.get("/gpu", description="Check if GPU is available.")
     def gpu_is_available() -> Message:

--- a/src/main.py
+++ b/src/main.py
@@ -41,6 +41,7 @@ that are used by the content management system.
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
+    environment=os.environ.get("ENV"),
     traces_sample_rate=1.0,
     # Samples 100% of transactions. We should decrease this value in the future.
     profiles_sample_rate=1.0,

--- a/src/models/summary.py
+++ b/src/models/summary.py
@@ -2,7 +2,7 @@ from .textbook import TextbookNames
 from .strapi import Chunk
 from typing import Optional, Dict, Union
 from pydantic import BaseModel, Field
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from spacy.tokens import Doc
 from enum import Enum
 from typing import Literal
@@ -20,6 +20,14 @@ class SummaryInputStrapi(BaseModel):
     )
     chat_history: Optional[str] = Field(
         default=None, description="The full chat history as a single string."
+    )
+    excluded_chunks: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "The slugs of chunks that should be excluded from consideration for STAIRS."
+            " For example, if the student has already correctly answered a constructed"
+            " response item about a chunk."
+        ),
     )
 
 
@@ -162,3 +170,4 @@ class Summary:
     chunks: list[ChunkWithWeight]
     page_slug: str
     chat_history: Union[Doc, None]
+    excluded_chunks: list[str] = field(default_factory=lambda: [])

--- a/src/models/summary.py
+++ b/src/models/summary.py
@@ -51,7 +51,7 @@ class SummaryResults(BaseModel):
 class ScoreType(str, Enum):
     containment = "Language Borrowing"
     containment_chat = "Language Borrowing (from iTELL AI)"
-    similarity = "Topic Similarity"
+    similarity = "Relevance"
     english = "English"
     content = "Content"
     wording = "Wording"
@@ -118,7 +118,7 @@ class StreamingSummaryResults(SummaryResultsWithFeedback):
                             "feedback": {"is_passed": False, "prompt": None},
                         },
                         {
-                            "type": "Topic Similarity",
+                            "type": "Relevance",
                             "feedback": {
                                 "is_passed": False,
                                 "prompt": (

--- a/src/models/summary.py
+++ b/src/models/summary.py
@@ -1,11 +1,16 @@
 from .textbook import TextbookNames
 from .strapi import Chunk
-from typing import Optional, Dict, Union
+from typing import Optional, Dict
 from pydantic import BaseModel, Field
 from dataclasses import dataclass, field
 from spacy.tokens import Doc
 from enum import Enum
 from typing import Literal
+
+
+class ChatMessage(BaseModel):
+    agent: Literal["user", "bot"]
+    text: str
 
 
 class SummaryInputStrapi(BaseModel):
@@ -18,8 +23,12 @@ class SummaryInputStrapi(BaseModel):
         description="Keys are chunk slugs and values are focus times in seconds.",
         example={"introduction-to-law-79t": 20},
     )
-    chat_history: Optional[str] = Field(
-        default=None, description="The full chat history as a single string."
+    chat_history: Optional[list[ChatMessage]] = Field(
+        default=None,
+        description=(
+            "The full chat history as a list of {'agent': 'user'/'bot', 'text': str}"
+            " dicts."
+        ),
     )
     excluded_chunks: Optional[list[str]] = Field(
         default=None,
@@ -169,5 +178,6 @@ class Summary:
     source: Doc
     chunks: list[ChunkWithWeight]
     page_slug: str
-    chat_history: Union[Doc, None]
+    chat_history: Optional[list[ChatMessage]]
+    bot_messages: Optional[Doc] = None
     excluded_chunks: list[str] = field(default_factory=lambda: [])

--- a/src/pipelines/chat.py
+++ b/src/pipelines/chat.py
@@ -39,6 +39,13 @@ async def ChatPipeline(
 
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output in results_generator:  # type: ignore
+            # Check if the last part of the output is the USER token
+            # If it is, remove this and any preceding whitespace
+            # before sending the final response.
+            if request_output.outputs[0].text.endswith("USER"):
+                request_output.outputs[0].text = (
+                    request_output.outputs[0].text[:-4].rstrip()
+                )
             ret = {
                 "request_id": request_id,
                 "text": request_output.outputs[0].text,

--- a/src/pipelines/chat.py
+++ b/src/pipelines/chat.py
@@ -26,7 +26,7 @@ else:
 engine = AsyncLLMEngine.from_engine_args(engine_args)
 
 
-async def ChatPipeline(
+async def chat_pipeline(
     prompt: str, sampling_params: SamplingParams, **kwargs
 ) -> AsyncGenerator[bytes, None]:
     """Generate completion for the request.
@@ -39,17 +39,19 @@ async def ChatPipeline(
 
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output in results_generator:  # type: ignore
+            out_text = request_output.outputs[0].text
+
             # Check if the last part of the output is the USER token
             # If it is, remove this and any preceding whitespace
             # before sending the final response.
-            if request_output.outputs[0].text.endswith("USER"):
-                request_output.outputs[0].text = (
-                    request_output.outputs[0].text[:-4].rstrip()
-                )
+            if out_text.endswith("USER"):
+                out_text = out_text[:-4].rstrip()
+
             ret = {
                 "request_id": request_id,
-                "text": request_output.outputs[0].text,
+                "text": out_text,
             }
+
             # Add any additional kwargs to the response
             # Used for returning the chunk_slug in the SERT response
             if kwargs:

--- a/src/pipelines/chat.py
+++ b/src/pipelines/chat.py
@@ -44,8 +44,8 @@ async def chat_pipeline(
             # Check if the last part of the output is the USER token
             # If it is, remove this and any preceding whitespace
             # before sending the final response.
-            if out_text.endswith("USER"):
-                out_text = out_text[:-4].rstrip()
+            if request_output.finished:
+                out_text = out_text.removesuffix("USER").rstrip()
 
             ret = {
                 "request_id": request_id,

--- a/src/sert.py
+++ b/src/sert.py
@@ -111,6 +111,7 @@ async def sert_generate(summary: Summary) -> AsyncGenerator[bytes, None]:
     # Make a dictionary to look up similarity scores by Slug
     similarity_dict = {
         match.chunk: match.similarity for match in least_similar_chunks.matches
+        if match.chunk not in summary.excluded_chunks
     }
 
     # Calculate final score for rereading: reading_time_score * similarity
@@ -119,6 +120,11 @@ async def sert_generate(summary: Summary) -> AsyncGenerator[bytes, None]:
         for chunk in summary.chunks
         if chunk.Slug in similarity_dict
     ]
+
+    if len(chunks) == 0:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No candidate chunks remain after accounting for 'excluded_chunks'."
 
     # Select the chunk with the lowest score
     selected_chunk, _ = min(chunks, key=lambda x: x[1])

--- a/src/sert.py
+++ b/src/sert.py
@@ -4,7 +4,7 @@
 from .models.summary import Summary, ChunkWithWeight
 from .models.embedding import RetrievalInput, RetrievalStrategy
 from .embedding import chunks_retrieve
-from .pipelines.chat import ChatPipeline
+from .pipelines.chat import chat_pipeline
 from .connections.strapi import Strapi
 from typing import AsyncGenerator
 
@@ -110,7 +110,8 @@ async def sert_generate(summary: Summary) -> AsyncGenerator[bytes, None]:
 
     # Make a dictionary to look up similarity scores by Slug
     similarity_dict = {
-        match.chunk: match.similarity for match in least_similar_chunks.matches
+        match.chunk: match.similarity
+        for match in least_similar_chunks.matches
         if match.chunk not in summary.excluded_chunks
     }
 
@@ -124,7 +125,8 @@ async def sert_generate(summary: Summary) -> AsyncGenerator[bytes, None]:
     if len(chunks) == 0:
         raise HTTPException(
             status_code=404,
-            detail=f"No candidate chunks remain after accounting for 'excluded_chunks'."
+            detail="No candidate chunks remain after accounting for 'excluded_chunks'.",
+        )
 
     # Select the chunk with the lowest score
     selected_chunk, _ = min(chunks, key=lambda x: x[1])
@@ -144,7 +146,7 @@ async def sert_generate(summary: Summary) -> AsyncGenerator[bytes, None]:
 
     sampling_params = SamplingParams(temperature=0.4, max_tokens=4096)
 
-    return await ChatPipeline(
+    return await chat_pipeline(
         prompt, sampling_params, chunk=selected_chunk.Slug, question_type=question_type
     )
 

--- a/src/summary_eval.py
+++ b/src/summary_eval.py
@@ -8,6 +8,7 @@ from .pipelines.containment import score_containment
 from .pipelines.summary import SummaryPipeline
 from .pipelines.keyphrases import suggest_keyphrases
 from .connections.strapi import Strapi
+from .embedding import page_similarity
 
 import gcld3
 from transformers import logging
@@ -82,8 +83,9 @@ async def summary_score(
         )
 
     # Check if summary is similar to source text
+    summary_embed = embedding_pipe(summary.summary.text)[0].tolist()
     results["similarity"] = (
-        embedding_pipe.score_similarity(summary.source.text, summary.summary.text)
+        await page_similarity(summary_embed, summary.page_slug)
         + 0.15
     )  # adding 0.15 to bring similarity score in line with old doc2vec model
 

--- a/src/summary_eval.py
+++ b/src/summary_eval.py
@@ -51,14 +51,22 @@ async def summary_score(
 
     weighted_chunks = weight_chunks(chunks, chunk_docs, summary_input.focus_time)
 
+    bot_messages = None
+    if summary_input.chat_history:
+        bot_messages = "\n".join(
+            [msg.text for msg in summary_input.chat_history if msg.agent == "bot"]
+        )
+
     # Create summary data object
     summary = Summary(
         summary=nlp(summary_input.summary),
         source=Doc.from_docs(chunk_docs),  # combine into a single doc
         chunks=weighted_chunks,
         page_slug=summary_input.page_slug,
-        chat_history=(
-            nlp(summary_input.chat_history) if summary_input.chat_history else None
+        chat_history=summary_input.chat_history,
+        bot_messages=nlp(bot_messages) if bot_messages else None,
+        excluded_chunks=(
+            summary_input.excluded_chunks if summary_input.excluded_chunks else []
         ),
     )
 
@@ -68,14 +76,15 @@ async def summary_score(
     results["containment"] = score_containment(summary.source, summary.summary)
 
     # Check if summary borrows language from chat history
-    if summary.chat_history:
+    if summary.bot_messages:
         results["containment_chat"] = score_containment(
-            summary.chat_history, summary.summary
+            summary.bot_messages, summary.summary
         )
 
     # Check if summary is similar to source text
     results["similarity"] = (
-        embedding_pipe.score_similarity(summary.source.text, summary.summary.text) + 0.15
+        embedding_pipe.score_similarity(summary.source.text, summary.summary.text)
+        + 0.15
     )  # adding 0.15 to bring similarity score in line with old doc2vec model
 
     # Generate keyphrase suggestions
@@ -102,7 +111,7 @@ async def summary_score(
 
     # Summary meets minimum requirements. Score it.
     input_text = summary.summary.text + "</s>" + summary.source.text
-    results["content"] = content_pipe(input_text)[0]["score"]
-    results["wording"] = wording_pipe(input_text)[0]["score"]
+    results["content"] = content_pipe(input_text)[0]["score"]  # type: ignore
+    results["wording"] = wording_pipe(input_text)[0]["score"]  # type: ignore
 
     return summary, SummaryResults(**results)


### PR DESCRIPTION
This PR combines a few minor updates and bugfixes:

- Revises prompts and sampling params to stop generation when the token "USER" is generated. The uppercase form is also a unique token (token id 11889), and is much less likely to be generated as part of the bot's response.
- Scrubs the final "USER" token from the bot's response (if it is generated) and any trailing whitespace. This could create a visual bug when rendering the token stream if a newline character is generated in the penultimate response, then scrubbed in the last response. It will probably look fine though -- we will see.
- Moved SERT import inside the GPU block of main.py since it requires a GPU
- Renamed similarity to "relevance"
- Add excluded_chunks field to score/summary/stairs endpoint and associated logic for excluding these chunks from the re-reading selection candidates
- restructured the chat_history field and added logic for calculating containment based only on the bot's messages.
- added in the new remote procedure call (RPC) for calculating similarity with the pre-generated embeddings for the page.
