### PR TITLE
Add genAI endpoint for explaining why user's constructed response item (CRI) is incorrect 

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,3 +10,4 @@ spacy>=3.0,<4.0
 supabase
 transformers>=4.31.0
 youtube_transcript_api>=0.6.0
+scipy==1.10.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,4 +10,4 @@ spacy>=3.0,<4.0
 supabase
 transformers>=4.31.0
 youtube_transcript_api>=0.6.0
-scipy==1.10.1
+scipy==1.12

--- a/src/chat.py
+++ b/src/chat.py
@@ -5,6 +5,7 @@ from typing import AsyncGenerator
 from .embedding import chunks_retrieve
 from .pipelines.chat import chat_pipeline, chat_CRI_pipeline
 from .connections.strapi import Strapi
+from fastapi import HTTPException
 
 from jinja2 import Template
 from vllm.sampling_params import SamplingParams

--- a/src/chat.py
+++ b/src/chat.py
@@ -3,7 +3,7 @@ from .models.chat import ChatInput, PromptInput, ChatInputCRI
 from .models.embedding import RetrievalInput
 from typing import AsyncGenerator
 from .embedding import chunks_retrieve
-from .pipelines.chat import chat_pipeline, chat_CRI_pipeline
+from .pipelines.chat import chat_pipeline
 from .connections.strapi import Strapi
 from fastapi import HTTPException
 
@@ -66,6 +66,7 @@ async def cri_chat(cri_input: ChatInputCRI) -> AsyncGenerator[bytes, None]:
     )
 
     target_properties = ['ConstructedResponse', 'Question', 'CleanText']
+    prompt_prefix = "Your response"
 
     for prop in target_properties:
         if getattr(chunk, prop) is None:
@@ -84,4 +85,5 @@ async def cri_chat(cri_input: ChatInputCRI) -> AsyncGenerator[bytes, None]:
     sampling_params = SamplingParams(
         temperature=0.4, max_tokens=4096, stop=["<|im_end|>"]
     )
-    return await chat_CRI_pipeline(prompt, sampling_params)
+
+    return await chat_pipeline(prompt, sampling_params, preface_text=prompt_prefix)

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,9 +1,9 @@
 # flake8: noqa E501
-from .models.chat import ChatInput, PromptInput
+from .models.chat import ChatInput, PromptInput, ChatInputCRI
 from .models.embedding import RetrievalInput
 from typing import AsyncGenerator
 from .embedding import chunks_retrieve
-from .pipelines.chat import chat_pipeline
+from .pipelines.chat import chat_pipeline, chat_CRI_pipeline
 from .connections.strapi import Strapi
 
 from jinja2 import Template
@@ -83,4 +83,4 @@ async def cri_chat(cri_input: ChatInputCRI) -> AsyncGenerator[bytes, None]:
     sampling_params = SamplingParams(
         temperature=0.4, max_tokens=4096, stop=["<|im_end|>"]
     )
-    return await chat_pipeline(prompt, sampling_params)
+    return await chat_CRI_pipeline(prompt, sampling_params)

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from .models.summary import (
 )
 from .models.answer import AnswerInputStrapi, AnswerInputSupaBase, AnswerResults
 from .models.embedding import ChunkInput, RetrievalInput, RetrievalResults
-from .models.chat import ChatInput, PromptInput
+from .models.chat import ChatInput, PromptInput, ChatInputCRI
 from .models.message import Message
 from .models.transcript import TranscriptInput, TranscriptResults
 from typing import Union, AsyncGenerator, Callable
@@ -179,7 +179,7 @@ async def generate_transcript(input_body: TranscriptInput) -> TranscriptResults:
 if not os.environ.get("ENV") == "development":
     import torch
     from src.embedding import embedding_generate, chunks_retrieve
-    from src.chat import moderated_chat, unmoderated_chat
+    from src.chat import moderated_chat, unmoderated_chat, cri_chat
     from .sert import sert_generate
 
     @router.get("/gpu", description="Check if GPU is available.")
@@ -206,6 +206,13 @@ if not os.environ.get("ENV") == "development":
         For testing purposes.
         """
         return StreamingResponse(await unmoderated_chat(input_body))
+
+    @router.post("/chat/CRI")
+    async def chat_cri(input_body: ChatInputCRI) -> StreamingResponse:
+        """Explains why a student's response to a constructed response item was evaluated
+        as incorrect
+        """
+        return StreamingResponse(await cri_chat(input_body))
 
     @router.post("/score/summary/stairs", response_model=StreamingSummaryResults)
     async def score_summary_with_stairs(

--- a/src/models/chat.py
+++ b/src/models/chat.py
@@ -21,6 +21,13 @@ class ChatInput(BaseModel):
     summary: Optional[str] = None
     message: str
 
+class ChatInputCRI(BaseModel):
+    """Explains why a student's response to a constructed response item is incorrect.
+    Only works with texts that have their content stored in Strapi."""
+
+    page_slug: str
+    chunk_slug: str
+    student_response: str
 
 class PromptInput(BaseModel):
     """Used for testing purposes. The user provides the full prompt that is

--- a/src/pipelines/chat.py
+++ b/src/pipelines/chat.py
@@ -59,3 +59,32 @@ async def chat_pipeline(
             yield (json.dumps(ret) + "\0").encode("utf-8")
 
     return stream_results()
+
+
+async def chat_CRI_pipeline(
+    prompt: str, sampling_params: SamplingParams, **kwargs
+) -> AsyncGenerator[bytes, None]:
+    """Generate completion for the request.
+    - prompt: the prompt to use for the generation.
+    - sampling_params: the sampling parameters (See `SamplingParams` for details).
+    """
+    request_id = random_uuid()
+
+    results_generator = engine.generate(prompt, sampling_params, request_id)
+
+    async def stream_CRI_results() -> AsyncGenerator[bytes, None]:
+        async for request_output in results_generator:  # type: ignore
+            out_text = "Your response" + request_output.outputs[0].text
+
+            ret = {
+                "request_id": request_id,
+                "text": out_text,
+            }
+
+            # Add any additional kwargs to the response
+            # Used for returning the chunk_slug in the SERT response
+            if kwargs:
+                ret.update(kwargs)
+            yield (json.dumps(ret) + "\0").encode("utf-8")
+
+    return stream_CRI_results()

--- a/src/transcript.py
+++ b/src/transcript.py
@@ -6,8 +6,12 @@ from urllib import parse
 
 
 async def transcript_generate(transcript_input: TranscriptInput) -> TranscriptResults:
-    qsl = parse.parse_qs(transcript_input.url.query)
-    video_code = qsl["v"][0]
+
+    if transcript_input.url.host == "youtu.be":
+        video_code = transcript_input.url.path[1:]
+    else:
+        qsl = parse.parse_qs(transcript_input.url.query)
+        video_code = qsl["v"][0]
 
     srt = YouTubeTranscriptApi.get_transcript(video_code)
 

--- a/templates/cri_chat.jinja2
+++ b/templates/cri_chat.jinja2
@@ -1,0 +1,24 @@
+<|im_start|>system
+You will be given a passage taken from a textbook called Principles of Macroeconomics, a question about the passage, the correct answer to the question, and a student's answer to the question evaluated to be incorrect. Your task is to reference the passage and the correct answer to explain to the students why their response is incorrect. Make your repsonse concise (50 words at most).
+<|im_end|>
+
+
+<|im_start|>
+Passage: {{clean_text}}
+
+Question: {{question}}
+
+Correct answer: {{golden_answer}}
+
+Student's incorrect answer: {{student_response}}
+
+To reiterate your task, you were given a passage taken from a textbook called Principles of Macroeconomics, a question about the passage, the correct answer to the question, and a student's answer to the question evaluated to be incorrect. Your task is to reference the passage and the correct answer to explain to the students why their response is incorrect. You have to make sure that your response is concise. Make absolutely sure that your response is less than 70 words.
+
+Here are a few sample responses:
+Your response is incorrect because the passage does not mention software tools for studying or gathering trace data. It only talks about paper-based questionnaires and oral reports.
+Your response, "multiple actors," is incorrect because it is too vague and does not capture the specific roles of the actors mentioned in the passage. The passage states that authors, instructional designers, front-line instructors, and learners are the ones who generate data and receive learning analytics. Therefore, a more accurate answer would be to list these four categories of actors.
+Your response is incorrect because it implies that computers can optimize to perform this task without human understanding and sense-making. However, the passage states that computers do not "understand" the difference between a dog and a fire hydrant, and that understanding, sense-making, and explanation are distinctively human pursuits.
+<|im_end|>
+
+<|im_start|>
+Your response

--- a/tests/test_chat_CRI.py
+++ b/tests/test_chat_CRI.py
@@ -1,0 +1,21 @@
+import pytest
+import os
+import json
+
+
+@pytest.mark.skipif(os.getenv("ENV") == "development", reason="Requires GPU.")
+async def test_chat_CRI(client):
+    response = await client.post(
+        "/chat/CRI",
+        json={
+            "page_slug": "emotional",
+            "chunk_slug": "Core-Themes-3-483t",
+            "student_response": "Predictions and goals.",
+        },
+    )
+    assert response.status_code == 200
+
+    try:
+        print(json.loads([w for w in response.content.split(b'\x00') if w != b''][-1])['text'])
+    except Exception as e:
+        print(e)

--- a/tests/test_summary_eval.py
+++ b/tests/test_summary_eval.py
@@ -2,7 +2,7 @@ async def test_summary_eval_strapi(client):
     response = await client.post(
         "/score/summary",
         json={
-            "page_slug": "what-is-law",
+            "page_slug": "emotional",
             "summary": "Think about it this way: In 2015 the labor force in the United States contained over 158 million workers, according to the U.S. Bureau of Labor Statistics. The total land area was 3,794,101 square miles. While these are certainly large numbers, they are not infinite. Because these resources are limited, so are the numbers of goods and services we produce with them. Combine this with the fact that human wants seem to be virtually infinite, and you can see why scarcity is a problem.',",  # noqa: E501
         },
     )

--- a/tests/test_summary_eval_stairs.py
+++ b/tests/test_summary_eval_stairs.py
@@ -8,7 +8,7 @@ async def test_summary_eval_stairs(client):
     response = await client.post(
         "/score/summary/stairs",
         json={
-            "page_slug": "what-is-law",
+            "page_slug": "emotional",
             "summary": "What is the meaning of life?",
         },
     )

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -8,3 +8,14 @@ async def test_generate_transcript(client):
         },
     )
     assert response.status_code == 200
+
+async def test_generate_transcript_short_URL(client):
+    response = await client.post(
+        "/generate/transcript",
+        json={
+            "url": "https://youtu.be/dQw4w9WgXcQ?si=IBqJdNYkuWAtbZgC",
+            "start_time": 50,
+            "end_time": 200,
+        },
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
- API endpoint expects student's response and the page_slug and chunk_slug. 

```
page_slug: str
chunk_slug: str
student_response: str
```

- Uses existing method (strapi.get_chunk(page_slug, chunk_slug)) to get relevant data from our Strapi DB.
- Includes version control for scipy (scipy==1.12) because of an issue with the newest stable version of scipy (1.13) [https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-gensim](https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-gensim)

- Flagging that two tests from the main branch (`test_summary_eval.py` and `test_summary_eval_stairs`) are not working (when tested directly from the main branch without any of my changes). Not sure what's going on here - maybe it's related to my dev container setup? In any case, doesn't seem related to any of the changes I've made in this branch since the test fails for the main branch in my setup.
- Let me know if anything needs to be changed.