### PR TITLE
Got rid of unneeded parameters

### DIFF
--- a/src/embedding.py
+++ b/src/embedding.py
@@ -87,9 +87,6 @@ async def delete_unused(input_body: DeleteUnusedInput) -> Response:
         db.table("embeddings")
         .select("chunk")
         .eq("page", input_body.page_slug)
-        .eq("chapter", input_body.chapter_slug)
-        .eq("module", input_body.module_slug)
-        .eq("text", input_body.text_slug)
         .execute()
         .data
     )

--- a/src/models/embedding.py
+++ b/src/models/embedding.py
@@ -54,8 +54,5 @@ class RetrievalResults(BaseModel):
 
 
 class DeleteUnusedInput(BaseModel):
-    text_slug: str
-    module_slug: Optional[str] = None
-    chapter_slug: Optional[str] = None
     page_slug: str
     chunk_slugs: list[str]


### PR DESCRIPTION
Currently, the server uses the text, module, and chapter slug, although none of these are needed - page slugs are unique across all pages. This will allow pages without a text/module/chapter to delete unused chunks.