### PR TITLE
Changing format of Server-Sent Events in Token Streams

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -229,11 +229,13 @@ if not os.environ.get("ENV") == "development":
         stream = await sert_generate(summary)
 
         async def stream_results() -> AsyncGenerator[bytes, None]:
-            yield (feedback.model_dump_json() + "\0").encode("utf-8")
+            yield f"event: summaryfeedback\ndata: {feedback.model_dump_json()}\n\n"
             async for ret in stream:
                 yield ret
 
-        return StreamingResponse(stream_results())
+        return StreamingResponse(
+            content=stream_results(), media_type="text/event-stream"
+        )
 
     @router.post("/generate/embedding")
     async def generate_embedding(input_body: ChunkInput) -> Response:

--- a/src/pipelines/chat.py
+++ b/src/pipelines/chat.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import AsyncGenerator
 
@@ -6,6 +5,8 @@ from vllm.sampling_params import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.utils import random_uuid
+
+from ..models.chat import ChatResponse
 
 # For local development on an RTX 3060 with 12GiB of VRAM
 if os.environ.get("ENV") == "gpu-development":
@@ -39,25 +40,18 @@ async def chat_pipeline(
 
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output in results_generator:  # type: ignore
-            out_text = request_output.outputs[0].text
+            generated_text = request_output.outputs[0].text
 
             # Check if the last part of the output is the USER token
             # If it is, remove this and any preceding whitespace
             # before sending the final response.
             if request_output.finished:
-                out_text = out_text.removesuffix("USER").rstrip()
+                generated_text = generated_text.removesuffix("USER").rstrip()
 
-            out_text = preface_text + out_text
+            out_text = preface_text + generated_text
 
-            ret = {
-                "request_id": request_id,
-                "text": out_text,
-            }
+            chat_output = ChatResponse(request_id=request_id, text=out_text, **kwargs)
 
-            # Add any additional kwargs to the response
-            # Used for returning the chunk_slug in the SERT response
-            if kwargs:
-                ret.update(kwargs)
-            yield (json.dumps(ret) + "\0").encode("utf-8")
+            yield f"event: completion\ndata: {chat_output.model_dump_json()}\n\n"
 
     return stream_results()

--- a/tests/test_summary_eval_stairs.py
+++ b/tests/test_summary_eval_stairs.py
@@ -4,37 +4,38 @@ from src.models.summary import SummaryResultsWithFeedback
 from pydantic import ValidationError
 
 
-@pytest.mark.skipif(os.getenv("ENV") == "development", reason="Requires GPU.")
 async def test_summary_eval_stairs_language(client):
-    # This test is not working with streaming. Currently using simple post test.
-    response = await client.post(
+    async with client.stream(
+        "POST",
         "/score/summary/stairs",
         json={
             "page_slug": "emotional",
             "summary": "Emotions are physical and mental states brought on by neurophysiological changes, variously associated with thoughts, feelings, behavioral responses, and a degree of pleasure or displeasure. There is no scientific consensus on a definition. Emotions are often intertwined with mood, temperament, personality, disposition, or creativity.",  # noqa: E501
         },
-    )
+    ) as response:
+        assert response.status_code == 200
 
-    assert response.status_code == 200
+        # We need to simulate the streaming response due to an issue with
+        # Starlette's TestClient https://github.com/encode/starlette/issues/1102
+        response = await anext(response.aiter_text())
+        stream = (chunk for chunk in response.split("\n\n"))
 
-    # We need to simulate the streaming response due to an issue with
-    # Starlette's TestClient https://github.com/encode/starlette/issues/1102
-    stream = (chunk for chunk in response.content.split(b"\0"))
+        # The first chunk is the feedback
+        feedback = next(stream).removeprefix("event: summaryfeedback\ndata: ")
 
-    # The first chunk is the feedback
-    feedback_bytes = next(stream)
+        # Checks that the feedback is a valid SummaryResultsWithFeedback object.
+        try:
+            feedback = SummaryResultsWithFeedback.model_validate_json(feedback)
+        except ValidationError as err:
+            print(err)
+            raise
 
-    # Checks that the feedback is a valid SummaryResultsWithFeedback object.
-    try:
-        feedback = SummaryResultsWithFeedback.model_validate_json(feedback_bytes)
-    except ValidationError as err:
-        print(err)
-        raise
+        # Check that the language score is passing
+        language = next(
+            item for item in feedback.prompt_details if item.type == "Language"
+        )
 
-    # Check that the language score is passing
-    language = next(item for item in feedback.prompt_details if item.type == "Language")
-
-    assert language.feedback.is_passed, "Language score should be passing."
+        assert language.feedback.is_passed, "Language score should be passing."
 
 
 @pytest.mark.skipif(os.getenv("ENV") == "development", reason="Requires GPU.")


### PR DESCRIPTION
I am proposing a change to the token stream format. I'd like to conform with the [SSE ](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) standard.

I'm not sure if this will help with [https://github.com/learlab/itell-strapi-demo/issues/24](https://github.com/learlab/itell-strapi-demo/issues/24), but it couldn't hurt to try.