### PR TITLE
Rpc-update

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -55,8 +55,8 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     )
 
     cited_chunks = [
-        chunk.chunk if chunk.chunk != "itell-documentation" else "[User Guide]"
-        for chunk in relevant_chunks.matches
+        match.chunk if match.page != "itell-documentation" else "[User Guide]"
+        for match in relevant_chunks.matches
     ]
 
     return await chat_pipeline(

--- a/src/chat.py
+++ b/src/chat.py
@@ -31,7 +31,7 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
     relevant_chunks = await chunks_retrieve(
         RetrievalInput(
             text_slug=text_meta.slug,
-            page_slug=chat_input.page_slug,
+            page_slugs=[chat_input.page_slug, "itell-documentation"],
             text=chat_input.message,
             similarity_threshold=0.2,
             match_count=1,

--- a/src/chat.py
+++ b/src/chat.py
@@ -54,7 +54,10 @@ async def moderated_chat(chat_input: ChatInput) -> AsyncGenerator[bytes, None]:
         student_summary=chat_input.summary,
     )
 
-    cited_chunks = [chunk.chunk for chunk in relevant_chunks.matches]
+    cited_chunks = [
+        chunk.chunk if chunk.chunk != "itell-documentation" else "[User Guide]"
+        for chunk in relevant_chunks.matches
+    ]
 
     return await chat_pipeline(
         prompt, sampling_params, event_type=EventType.chat, context=cited_chunks

--- a/src/embedding.py
+++ b/src/embedding.py
@@ -47,7 +47,7 @@ async def chunks_retrieve(input_body: RetrievalInput) -> RetrievalResults:
     }
 
     try:
-        matches = db.rpc("retrieve_chunks_test", query_params).execute().data
+        matches = db.rpc("retrieve_chunks", query_params).execute().data
     except (TypeError, AttributeError) as error:
         raise HTTPException(status_code=500, detail=str(error))
 

--- a/src/embedding.py
+++ b/src/embedding.py
@@ -42,13 +42,12 @@ async def chunks_retrieve(input_body: RetrievalInput) -> RetrievalResults:
         "embed": content_embedding,
         "match_threshold": input_body.similarity_threshold,
         "match_count": input_body.match_count,
-        "include_help": input_body.include_help,
         "retrieve_strategy": input_body.retrieve_strategy,
-        "page_slug": input_body.page_slug,
+        "page_slugs": input_body.page_slugs,
     }
 
     try:
-        matches = db.rpc("retrieve_chunks", query_params).execute().data
+        matches = db.rpc("retrieve_chunks_test", query_params).execute().data
     except (TypeError, AttributeError) as error:
         raise HTTPException(status_code=500, detail=str(error))
 

--- a/src/models/embedding.py
+++ b/src/models/embedding.py
@@ -19,10 +19,9 @@ class RetrievalStrategy(str, Enum):
 
 class RetrievalInput(BaseModel, use_enum_values=True):
     text_slug: Optional[str] = None
-    page_slug: str
+    page_slugs: list[str]
     text: str  # text to compare to (student summary)
     similarity_threshold: Optional[float] = 0.0
-    include_help: Optional[bool] = True
     retrieve_strategy: Optional[RetrievalStrategy] = RetrievalStrategy.most_similar
     match_count: Optional[int] = 1
 

--- a/src/models/embedding.py
+++ b/src/models/embedding.py
@@ -27,6 +27,7 @@ class RetrievalInput(BaseModel, use_enum_values=True):
 
 
 class Match(BaseModel):
+    page: str
     chunk: str
     content: str
     similarity: float

--- a/src/sert.py
+++ b/src/sert.py
@@ -38,9 +38,8 @@ async def sert_chat(summary: Summary) -> AsyncGenerator[bytes, None]:
     least_similar_chunks = await chunks_retrieve(
         RetrievalInput(
             text_slug=text_meta.slug,
-            page_slug=summary.page_slug,
+            page_slugs=[summary.page_slug],
             text=summary.summary.text,
-            include_help=False,
             retrieve_strategy=RetrievalStrategy.least_similar,
             match_count=10,
         )

--- a/src/summary_feedback.py
+++ b/src/summary_feedback.py
@@ -100,7 +100,7 @@ class Wording:
 
 
 class Language:
-    # Set to 2.5 for Prolific testing
+    # Set to 2.0 for Prolific testing
     rubric = [
         "Your summary shows a very basic understanding of lexical and syntactic structures.",  # noqa: E501
         "Your summary shows an understanding of lexical and syntactic structures.",
@@ -108,7 +108,7 @@ class Language:
         "Your summary shows an excellent range of lexical and syntactic structures.",
         "Your summary shows an excellent range of lexical and syntactic structures.",
     ]
-    threshold = 2.5
+    threshold = 2.0
 
     @classmethod
     def generate_feedback(cls, score: float):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -19,7 +19,8 @@ async def test_chat(client):
         stream = (chunk for chunk in response.split("\n\n"))
 
         # The first chunk is the feedback
-        first_chunk = next(stream).removeprefix(f"event: {EventType.chat}\ndata: ")
+        first_chunk = next(stream).removeprefix(
+            f"event: {EventType.chat}\ndata: ")
 
         # Checks that the first chunk is a valid ChatResponse object.
         try:
@@ -30,3 +31,34 @@ async def test_chat(client):
 
     # Check that a chunk was cited
     assert len(message.context) != 0, "A chunk should be cited."
+
+
+async def test_user_guide_rag(client):
+    async with client.stream(
+        "POST",
+        "/chat",
+        json={
+            "page_slug": "emotional",
+            "message": "How do I navigate the iTELL Dashboard?",
+        },
+    ) as response:
+        assert response.status_code == 200
+
+        # We need to simulate the streaming response due to an issue with
+        # Starlette's TestClient https://github.com/encode/starlette/issues/1102
+        response = await anext(response.aiter_text())
+        stream = (chunk for chunk in response.split("\n\n"))
+
+        # The first chunk is the feedback
+        first_chunk = next(stream).removeprefix(
+            f"event: {EventType.chat}\ndata: ")
+
+        # Checks that the first chunk is a valid ChatResponse object.
+        try:
+            message = ChatResponse.model_validate_json(first_chunk)
+        except ValidationError as err:
+            print(err)
+            raise
+
+    # Check that the first cited chunk is from the User Guide
+    assert message.context[0] == "[User Guide]", "The user guide should be cited."

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -47,7 +47,7 @@ async def test_retrieve_chunks(client):
         "/retrieve/chunks",
         json={
             "text_slug": "test_text",
-            "page_slug": "test_page",
+            "page_slugs": ["test_page"],
             "text": "Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.",  # noqa: E501
         },
     )

--- a/tests/test_summary_eval_stairs.py
+++ b/tests/test_summary_eval_stairs.py
@@ -9,7 +9,7 @@ async def test_summary_eval_stairs_language(client):
         "/score/summary/stairs",
         json={
             "page_slug": "emotional",
-            "summary": "Emotions are physical and mental states brought on by neurophysiological changes, variously associated with thoughts, feelings, behavioral responses, and a degree of pleasure or displeasure. There is no scientific consensus on a definition. Emotions are often intertwined with mood, temperament, personality, disposition, or creativity.",  # noqa: E501
+            "summary": "Emotions are physical and mental states brought on by neurophysiological changes, variously associated with thoughts, feelings, behavioral responses, and a degree of pleasure or displeasure. While there is no scientific consensus on a definition, emotions are often intertwined with mood, temperament, personality, disposition, or creativity.",  # noqa: E501
         },
     ) as response:
         assert response.status_code == 200
@@ -36,7 +36,9 @@ async def test_summary_eval_stairs_language(client):
             item for item in feedback.prompt_details if item.type == "Language"
         )
 
-        assert language.feedback.is_passed, "Language score should be passing."
+        if not language.feedback.is_passed:
+            print(feedback.model_dump_json())
+            raise AssertionError("Language score should be passing.")
 
 
 async def test_bad_page_slug(client):


### PR DESCRIPTION
This one makes some changes to the RPC function. It removes the "include_help" parameter and changes "page_slug" to "page_slugs". To include the user guide in RAG, we just add the slug of the user guide to the retrieve_chunks query. This is a more generalizable approach.

The RPC also returns page slugs now, to make it easier to keep track of where the chunk is from when filtering on multiple pages.

This branch currently uses an RPC called "retrieve_chunks_test". Once it is approved, I will update the "retrieve_chunks" function on Supabase and switch this branch to use that version during the build/deploy process.

This also fixes a failing test. A recent change to the language scoring threshold caused our test summary to fail on Language. A small tweak to this summary gets it to pass.