### PR TITLE
current_chunk param and new /chat/SERT endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ huggingface
 #logs
 logs
 
+# Testing Data
+tests/performance/data
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from ..services.chat import cri_chat, moderated_chat, unmoderated_chat
-from ..schemas.chat import ChatInput, ChatInputCRI, PromptInput
 from ..logging.logging_router import LoggingRoute, LoggingStreamingResponse
+from ..schemas.chat import ChatInput, ChatInputCRI, ChatInputSERT, PromptInput
+from ..services.chat import cri_chat, moderated_chat, sert_chat, unmoderated_chat
 
 router = APIRouter(route_class=LoggingRoute)
 
@@ -46,4 +46,21 @@ async def chat_cri(
     """
     strapi = request.app.state.strapi
     chat_stream = await cri_chat(input_body, strapi)
+    return LoggingStreamingResponse(content=chat_stream, media_type="text/event-stream")
+
+
+@router.post("/chat/SERT")
+async def chat_sert(
+    input_body: ChatInputSERT,
+    request: Request,
+) -> StreamingResponse:
+    """Responds to user queries incorporating relevant chunks from the current page.
+
+    The response is a StreamingResponse wih the following fields:
+    - **request_id**: a unique identifier for the request
+    - **text**: the response text
+    """
+    strapi = request.app.state.strapi
+    chat_stream = await sert_chat(input_body, strapi)
+
     return LoggingStreamingResponse(content=chat_stream, media_type="text/event-stream")

--- a/src/schemas/chat.py
+++ b/src/schemas/chat.py
@@ -22,6 +22,23 @@ class ChatInput(BaseModel):
     )
     summary: Optional[str] = None
     message: str
+    current_chunk: Optional[str] = None
+
+
+class ChatInputSERT(BaseModel):
+    """Chat input for SERT dialogues."""
+
+    page_slug: str
+    history: list[ChatMessage] = Field(
+        default_factory=list,
+        description=(
+            "The full chat history as a list of {'agent': 'user'|'bot', 'text': str}"
+            " dicts."
+        ),
+    )
+    summary: Optional[str] = None
+    message: str
+    current_chunk: str
 
 
 class ChatInputCRI(BaseModel):

--- a/src/services/chat.py
+++ b/src/services/chat.py
@@ -7,8 +7,15 @@ from vllm.sampling_params import SamplingParams
 from ..dependencies.strapi import Strapi
 from ..dependencies.supabase import SupabaseClient
 from ..pipelines.chat import chat_pipeline
-from ..schemas.chat import ChatInput, ChatInputCRI, EventType, PromptInput
-from ..schemas.embedding import RetrievalInput
+from ..schemas.chat import (
+    ChatInput,
+    ChatInputCRI,
+    ChatInputSERT,
+    EventType,
+    PromptInput,
+)
+from ..schemas.embedding import Match, RetrievalInput
+from ..schemas.strapi import Chunk
 from ..schemas.summary import Summary
 
 with open("templates/chat.jinja2", "r", encoding="utf8") as file_:
@@ -21,6 +28,18 @@ with open("templates/language_feedback.jinja2", "r", encoding="utf8") as file_:
     language_feedback_template = Template(file_.read())
 
 sampling_params = SamplingParams(temperature=0.4, max_tokens=4096)
+
+
+def choose_relevant_chunk(relevant_chunks: list[Match], current_chunk: str):
+    if len(relevant_chunks.matches) == 0:
+        return None
+
+    relevant_chunk_dict = {match.chunk: match for match in relevant_chunks.matches}
+
+    if current_chunk in relevant_chunk_dict:
+        return relevant_chunk_dict[current_chunk]
+    else:
+        return relevant_chunks.matches[0]
 
 
 async def moderated_chat(
@@ -36,15 +55,12 @@ async def moderated_chat(
             text_slug=text_meta.Slug,
             page_slugs=[chat_input.page_slug, "itell-documentation"],
             text=chat_input.message,
-            similarity_threshold=0.2,
-            match_count=1,
+            similarity_threshold=0.15,
+            match_count=10,
         )
     )
 
-    if len(relevant_chunks.matches) > 0:
-        relevant_chunk = relevant_chunks.matches[0]
-    else:
-        relevant_chunk = None
+    relevant_chunk = choose_relevant_chunk(relevant_chunks, chat_input.current_chunk)
 
     if relevant_chunk and relevant_chunk.page == "itell-documentation":
         text_name = "iTELL Documentation"
@@ -53,29 +69,25 @@ async def moderated_chat(
         text_name = text_meta.Title
         text_info = text_meta.Description
 
-    # TODO: Retrieve Examples
-    # We can set up a database of a questions and responses
-    # that the bot will use as a reference.
-
     # Get last 4 messages from chat history
-    chat_history = chat_input.history[-4:]
+    chat_history = [(msg.agent, msg.text) for msg in chat_input.history[-4:]]
 
     prompt = prompt_template.render(
         text_name=text_name,
         text_info=text_info,
         context=relevant_chunk.content if relevant_chunk else None,
-        chat_history=[(msg.agent, msg.text) for msg in chat_history],
+        chat_history=chat_history,
         user_message=chat_input.message,
         student_summary=chat_input.summary,
     )
 
-    cited_chunks = [
-        match.chunk if match.page != "itell-documentation" else "[User Guide]"
-        for match in relevant_chunks.matches
-    ]
+    if relevant_chunk.page == "itell-documentation":
+        cited_chunk = "[User Guide]"
+    else:
+        cited_chunk = relevant_chunk.chunk
 
     return await chat_pipeline(
-        prompt, sampling_params, event_type=EventType.chat, context=cited_chunks
+        prompt, sampling_params, event_type=EventType.chat, context=cited_chunk
     )
 
 
@@ -85,6 +97,29 @@ async def unmoderated_chat(raw_chat_input: PromptInput) -> AsyncGenerator[bytes,
         sampling_params,
         event_type=EventType.chat,
     )
+
+
+async def sert_chat(
+    chat_input: ChatInputSERT, strapi: Strapi
+) -> AsyncGenerator[bytes, None]:
+    text_meta = await strapi.get_text_meta(chat_input.page_slug)
+    current_chunk: Chunk = await strapi.get_chunk(
+        chat_input.page_slug, chat_input.current_chunk
+    )
+
+    # Get last 4 messages from chat history
+    chat_history = [(msg.agent, msg.text) for msg in chat_input.history[-4:]]
+
+    prompt = prompt_template.render(
+        text_name=text_meta.Title,
+        text_info=text_meta.Description,
+        context=current_chunk.CleanText,
+        chat_history=chat_history,
+        user_message=chat_input.message,
+        student_summary=chat_input.summary,
+    )
+
+    return await chat_pipeline(prompt, sampling_params, event_type=EventType.chat)
 
 
 async def cri_chat(


### PR DESCRIPTION
This PR adds a new paramater to /chat requests called "current_chunk".

/chat endpoint
When performing retrieval augmented generation (RAG), iTELL AI will now automatically select the current chunk if it is provided and it exists in the top 10 most relevant chunks that it retrieves.

/chat/SERT endpoint
The "current_chunk" is a required paramater and will completely bypass RAG. It is always selected, as the conversation is intended to remain focused on the current chunk.

These were relatively simple changes, but I think we will wait to merge until after Prolific testing.