### PR TITLE
use supabase RPC for page_similarity

### DIFF
--- a/src/dependencies/faiss.py
+++ b/src/dependencies/faiss.py
@@ -98,6 +98,7 @@ class FAISS_Wrapper:
                     and similarities[0][j] >= input_body.similarity_threshold
                 ):
                     search_docs.append((doc, similarities[0][j]))
+
         search_docs = sorted(search_docs, key=lambda x: x[1], reverse=True)[
             0 : input_body.match_count
         ]

--- a/src/dependencies/supabase.py
+++ b/src/dependencies/supabase.py
@@ -1,8 +1,13 @@
-from fastapi import Response
+from fastapi import HTTPException, Response
 from supabase.client import AsyncClient
 
 from ..pipelines.embed import EmbeddingPipeline
-from ..schemas.embedding import ChunkInput, DeleteUnusedInput
+from ..schemas.embedding import (
+    ChunkInput, 
+    DeleteUnusedInput,
+    RetrievalInput,
+    RetrievalResults,
+)
 
 
 class SupabaseClient(AsyncClient):
@@ -66,3 +71,44 @@ class SupabaseClient(AsyncClient):
             )
 
         return Response(status_code=202)
+
+    async def retrieve_chunks(self, input_body: RetrievalInput) -> RetrievalResults:
+        embedding = await self.embed(input_body.text)
+
+        query_params = {
+            "embed": embedding,
+            "match_threshold": input_body.similarity_threshold,
+            "match_count": input_body.match_count,
+            "retrieve_strategy": input_body.retrieve_strategy,
+            "page_slugs": input_body.page_slugs,
+        }
+
+        try:
+            response = await self.rpc("retrieve_chunks", query_params).execute()
+        except (TypeError, AttributeError) as error:
+            raise HTTPException(status_code=500, detail=str(error))
+
+        matches = response.data
+
+        return RetrievalResults(matches=matches)
+
+    async def page_similarity(self, embedding: list[float], page_slug: str) -> float:
+        """Returns the similarity between the embedding and the target page."""
+
+        query_params = {
+            "summary_embedding": embedding,
+            "target_page": page_slug,
+        }
+
+        try:
+            response = await self.rpc("page_similarity", query_params).execute()
+        except (TypeError, AttributeError) as error:
+            raise HTTPException(status_code=500, detail=str(error))
+
+        similarity = response.data[0]["similarity"]
+
+        if similarity is None:
+            message = f"Page similarity not found for {page_slug}"
+            raise HTTPException(status_code=404, detail=message)
+
+        return similarity

--- a/src/routers/score.py
+++ b/src/routers/score.py
@@ -65,8 +65,9 @@ async def score_summary_with_stairs(
     - **question_type**: the type of SERT question
     """
     strapi = request.app.state.strapi
+    supabase = request.app.state.supabase
     faiss = request.app.state.faiss
-    summary, results = await summary_score(input_body, strapi, faiss)
+    summary, results = await summary_score(input_body, strapi, supabase, faiss)
 
     feedback: SummaryResultsWithFeedback = summary_feedback(results)
 

--- a/src/services/summary_eval.py
+++ b/src/services/summary_eval.py
@@ -47,6 +47,7 @@ def weight_chunks(
 async def summary_score(
     summary_input: SummaryInputStrapi,
     strapi: Strapi,
+    supabase: SupabaseClient,
     faiss: FAISS_Wrapper,
 ) -> tuple[Summary, SummaryResults]:
     """Checks summary for text copied from the source and for semantic
@@ -95,7 +96,7 @@ async def summary_score(
     # Check if summary is similar to source text
     summary_embed = embedding_pipe(summary.summary.text)[0].tolist()
     results["similarity"] = (
-        await faiss.page_similarity(summary_embed, summary.page_slug) + 0.15
+        await supabase.page_similarity(summary_embed, summary.page_slug) + 0.15
     )  # adding 0.15 to bring similarity score in line with old doc2vec model
 
     # Generate keyphrase suggestions


### PR DESCRIPTION
FAISS vector store was returning -3.34831599667202E+38 for summaries on page `5-experimental-and-clinical-psychologists`.

Reverting to Supabase RPC function until we understand the source of the issue.