### PR TITLE
Dynamic Scoring Tweaks

### DIFF
--- a/src/pipelines/conjugate_normal.py
+++ b/src/pipelines/conjugate_normal.py
@@ -51,7 +51,9 @@ class ConjugateNormal:
 
     @property
     def threshold(self):
-        return stats.norm.ppf(self.percentile, loc=self.mu, scale=self.sigma)
+        df = 2 * self.alpha
+        scale = np.sqrt(self.beta * (1 + 1 / self.k) / self.alpha)
+        return stats.t.ppf(self.percentile, df=df, loc=self.mu, scale=scale)
 
     def sum_square_diffs(self, A, B):
         """Sum of squared differences"""

--- a/src/schemas/summary.py
+++ b/src/schemas/summary.py
@@ -38,15 +38,23 @@ class SummaryInputStrapi(BaseModel):
         default_factory=list,
         description="A list of the user's previous content scores.",
     )
+    enrolled_in_class: bool = Field(
+        default=False,
+        description=(
+            "Whether the student is enrolled in a class."
+            "The volume prior will not be updated if the student"
+            "is not enrolled in a class."
+        ),
+    )
 
 
 class SummaryInputTest(SummaryInputStrapi):
     passing_content: bool = Field(
-        description="Whether the summary response is passing or failing on content.",        
+        description="Whether the summary response is passing or failing on content.",
     )
 
 
-class _SummaryResults(BaseModel):
+class SummaryScoreResults(BaseModel):
     """Intermediate Object for Storing Summary Scores"""
 
     containment: float

--- a/src/services/summary_feedback.py
+++ b/src/services/summary_feedback.py
@@ -3,8 +3,8 @@ import tomllib
 from ..pipelines.feedback_processor import FeedbackProcessor
 from ..schemas.summary import (
     SummaryMetrics,
-    _SummaryResults,
     SummaryResultsWithFeedback,
+    SummaryScoreResults,
 )
 
 feedback_processors = {}
@@ -14,7 +14,7 @@ with open("assets/summary_feedback.toml", "rb") as f:
         feedback_processors[score_type] = FeedbackProcessor(**values)
 
 
-def summary_feedback(results: _SummaryResults) -> SummaryResultsWithFeedback:
+def summary_feedback(results: SummaryScoreResults) -> SummaryResultsWithFeedback:
     """Provide feedback on a summary based on the results
     of the summary scoring model."""
 


### PR DESCRIPTION
This PR introduces two tweaks to the dynamic content score thresholds.

1. Fixes a mistake where the code was using a normal distribution to predict the 20th percentile of the scoring distribution. The correct distribution for the posterior predictive is a Student's T. This will only impact the predicted threshold for small sample sizes.
2. Adds an "enrolled_in_class" parameter to the summary scoring request, with a defualt value of False. The volume prior will only be updated if the student is enrolled in a class.